### PR TITLE
feat!: allow version to be optional

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: '*'
+        update-types: # Prevent Cargo.toml patch updates
+          - version-update:semver-patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,21 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: nightly
           override: true
           components: rustfmt
 
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+        run: |
+          cargo fmt -- --check
 
   check:
     name: Compilation check
@@ -42,19 +39,17 @@ jobs:
           - 1.41.0
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust ${{ matrix.rust }}
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: |
+          cargo check
 
   clippy:
     name: Lint check
@@ -67,18 +62,15 @@ jobs:
           - 1.41.0
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust ${{ matrix.rust }}
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
           components: clippy
 
       - name: Run lints
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: |
+          cargo clippy -- -D warnings

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,25 +15,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: nightly
           override: true
 
       - name: Generate documentation
-        uses: actions-rs/cargo@v1
         env:
           RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
-        with:
-          command: doc
-          args: --workspace --no-deps
+        run: |
+          cargo doc --workspace --no-deps
 
       - name: Deploy documentation
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0.57"
-thiserror = "1.0.20"
+thiserror = "2.0.12"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ pub struct Package {
     /// The package name.
     pub name: String,
     /// The package version.
-    pub version: String,
+    pub version: Option<String>,
     /// The optional package description.
     pub description: Option<String>,
     /// The optional list of keywords.

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -6,7 +6,7 @@ fn test_de_minimal() {
     let s = include_str!("./minimal.json");
     let package = Package::from_str(s).unwrap();
     assert_eq!(package.name, "my-awesome-package");
-    assert_eq!(package.version, "1.0.0");
+    assert_eq!(package.version, Some("1.0.0".to_string()));
 }
 
 #[test]
@@ -16,7 +16,7 @@ fn test_de_default() {
     let git_url = "https://github.com/<user>/my_package.git";
 
     assert_eq!(package.name, "my_package");
-    assert_eq!(package.version, "1.0.0");
+    assert_eq!(package.version, Some("1.0.0".to_string()));
 
     assert!(package.description.unwrap().is_empty());
     assert_eq!(package.main.unwrap(), "index.js");


### PR DESCRIPTION
### Changes
- BREAKING: Allow version to be optional
- Upgrade thiserror
- Update GitHub Actions
- Let Dependabot update Cargo and GitHub Actions

Closes #9

